### PR TITLE
More sophisticated build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # s4-wormhole-convergence-agent
+
 The convergence agent for the magic-wormhole-enabled S4 signup process.
+
+## Building
+
+Easiest way is to build
+with [stack](https://docs.haskellstack.org/en/stable/README/).
+
+```console
+$ stack build
+```

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,22 @@
+name: s4-wormhole-convergence-agent
+version: 0.1.0
+synopsis: The convergence agent for the magic-wormhole-enabled S4 signup process.
+description: Please see README.md
+maintainer: Jean-Paul Calderone <exarkun@twistedmatrix.org>
+license: MIT
+github: LeastAuthority/s4-wormhole-convergence-agent
+category: Web
+
+ghc-options: -Wall -Werror
+
+dependencies:
+  - base >= 4.9 && < 5
+
+executables:
+  wsmain:
+    main: wsmain.hs
+    dependencies:
+      - aeson
+      - bytestring
+      - text
+      - websockets

--- a/s4-wormhole-convergence-agent.cabal
+++ b/s4-wormhole-convergence-agent.cabal
@@ -1,0 +1,31 @@
+-- This file has been generated from package.yaml by hpack version 0.15.0.
+--
+-- see: https://github.com/sol/hpack
+
+name:           s4-wormhole-convergence-agent
+version:        0.1.0
+synopsis:       The convergence agent for the magic-wormhole-enabled S4 signup process.
+description:    Please see README.md
+category:       Web
+homepage:       https://github.com/LeastAuthority/s4-wormhole-convergence-agent#readme
+bug-reports:    https://github.com/LeastAuthority/s4-wormhole-convergence-agent/issues
+maintainer:     Jean-Paul Calderone <exarkun@twistedmatrix.org>
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+cabal-version:  >= 1.10
+
+source-repository head
+  type: git
+  location: https://github.com/LeastAuthority/s4-wormhole-convergence-agent
+
+executable wsmain
+  main-is: wsmain.hs
+  ghc-options: -Wall -Werror
+  build-depends:
+      base >= 4.9 && < 5
+    , aeson
+    , bytestring
+    , text
+    , websockets
+  default-language: Haskell2010

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-8.9
+
+packages:
+  - .


### PR DESCRIPTION
I figured out GitHub.

* `package.yaml` is the human-edited one
* `stack.yaml` too, but it's pretty minimal. The idea is that it's used to pick a known-good set of dependencies (in this case, lts-8.9)
* `s4-wormhole-convergence-agent.cabal` is generated. You can probably get away with not version-controlling it, but most packages I've seen keep it
* Requires [stack](https://docs.haskellstack.org/en/stable/README/)

Build with `stack build` or `stack build --fast` for shorter compile times. When you add tests, you can test with `stack test`.

Once you've got this set up, you can use [intero](https://commercialhaskell.github.io/intero/) in your Emacs, which is *not* as good as it advertises but is still pretty good. It sets up flycheck and provides working go-to-definition and show-type-at-point routines.

